### PR TITLE
Fix registration data model

### DIFF
--- a/src/midgard/pages/Register/Register.js
+++ b/src/midgard/pages/Register/Register.js
@@ -90,7 +90,7 @@ function Register({ dispatch, loading, history, loaded, error }) {
       username: username.value,
       email: email.value,
       password: password.value,
-      organization: { name: organization_name.value },
+      organization_name: organization_name.value,
       first_name: first_name.value,
       last_name: last_name.value,
     };


### PR DESCRIPTION
## Purpose
POST /coreuser currently gives a status 400 with the error `{"organization_name":["Not a valid string."]}`