### PR TITLE
Cleanup styles on auth pages

### DIFF
--- a/src/midgard/pages/Login/Login.js
+++ b/src/midgard/pages/Login/Login.js
@@ -46,13 +46,18 @@ const useStyles = makeStyles((theme) => ({
   },
   form: {
     width: "100%",
-    marginTop: theme.spacing(1),
+    marginTop: theme.spacing(2),
   },
   submit: {
     margin: theme.spacing(3, 0, 2),
   },
   logo: {
-    width: "100%",
+    width: "12.5rem",
+    maxWidth: "100%",
+  },
+  textField: {
+    minHeight: "5rem",
+    margin: "0.25rem 0",
   },
   buttonProgress: {
     position: "absolute",
@@ -144,6 +149,7 @@ function Login({ dispatch, loading, history }) {
                 helperText={
                   error && error.username ? error.username.message : ""
                 }
+                className={classes.textField}
                 onBlur={(e) => handleBlur(e, "required", username)}
                 {...username.bind}
               />
@@ -161,6 +167,7 @@ function Login({ dispatch, loading, history }) {
                 helperText={
                   error && error.password ? error.password.message : ""
                 }
+                className={classes.textField}
                 onBlur={(e) => handleBlur(e, "required", password)}
                 {...password.bind}
               />
@@ -173,7 +180,7 @@ function Login({ dispatch, loading, history }) {
                   className={classes.submit}
                   disabled={loading || submitDisabled()}
                 >
-                  Sign In
+                  Sign in
                 </Button>
                 {loading && (
                   <CircularProgress
@@ -202,7 +209,7 @@ function Login({ dispatch, loading, history }) {
           </div>
         </CardContent>
       </Card>
-      <Box mt={8}>
+      <Box mt={8} mb={1}>
         <Copyright />
       </Box>
     </Container>

--- a/src/midgard/pages/Register/Register.js
+++ b/src/midgard/pages/Register/Register.js
@@ -43,13 +43,18 @@ const useStyles = makeStyles((theme) => ({
   },
   form: {
     width: "100%",
-    marginTop: theme.spacing(1),
+    marginTop: theme.spacing(2),
   },
   submit: {
     margin: theme.spacing(3, 0, 2),
   },
   logo: {
-    width: "100%",
+    width: "12.5rem",
+    maxWidth: "100%",
+  },
+  textField: {
+    minHeight: "5rem",
+    margin: "0.25rem 0",
   },
   buttonProgress: {
     position: "absolute",
@@ -166,6 +171,7 @@ function Register({ dispatch, loading, history, loaded, error }) {
                     helperText={
                       formError.first_name ? formError.first_name.message : ""
                     }
+                    className={classes.textField}
                     onBlur={(e) => handleBlur(e, "required", first_name)}
                     {...first_name.bind}
                   />
@@ -183,6 +189,7 @@ function Register({ dispatch, loading, history, loaded, error }) {
                     helperText={
                       formError.last_name ? formError.last_name.message : ""
                     }
+                    className={classes.textField}
                     onBlur={(e) => handleBlur(e)}
                     {...last_name.bind}
                   />
@@ -203,6 +210,7 @@ function Register({ dispatch, loading, history, loaded, error }) {
                     helperText={
                       formError.username ? formError.username.message : ""
                     }
+                    className={classes.textField}
                     onBlur={(e) => handleBlur(e, "required", username)}
                     {...username.bind}
                   />
@@ -220,6 +228,7 @@ function Register({ dispatch, loading, history, loaded, error }) {
                     type="email"
                     error={formError.email && formError.email.error}
                     helperText={formError.email ? formError.email.message : ""}
+                    className={classes.textField}
                     onBlur={(e) => handleBlur(e, "email", email)}
                     {...email.bind}
                   />
@@ -245,6 +254,7 @@ function Register({ dispatch, loading, history, loaded, error }) {
                         ? formError.organization_name.message
                         : ""
                     }
+                    className={classes.textField}
                     onBlur={(e) => handleBlur(e, "required", organization_name)}
                     {...organization_name.bind}
                   />
@@ -266,6 +276,7 @@ function Register({ dispatch, loading, history, loaded, error }) {
                     helperText={
                       formError.password ? formError.password.message : ""
                     }
+                    className={classes.textField}
                     onBlur={(e) => handleBlur(e, "required", password)}
                     {...password.bind}
                   />
@@ -286,6 +297,7 @@ function Register({ dispatch, loading, history, loaded, error }) {
                     helperText={
                       formError.re_password ? formError.re_password.message : ""
                     }
+                    className={classes.textField}
                     onBlur={(e) => handleBlur(e, "confirm", re_password)}
                     {...re_password.bind}
                   />
@@ -312,7 +324,7 @@ function Register({ dispatch, loading, history, loaded, error }) {
               <Grid container>
                 <Grid item>
                   <Link href={routes.LOGIN} variant="body2" color="secondary">
-                    {"Go Back To Login"}
+                    {"Already have an account? Sign in"}
                   </Link>
                 </Grid>
               </Grid>
@@ -320,7 +332,7 @@ function Register({ dispatch, loading, history, loaded, error }) {
           </div>
         </CardContent>
       </Card>
-      <Box mt={8}>
+      <Box mt={8} mb={1}>
         <Copyright />
       </Box>
     </Container>


### PR DESCRIPTION
## Purpose
- Prevent text fields from jumping when validation messages are shown.
- Make logo same size on registration and login pages.
- Minor action text changes